### PR TITLE
fix: would not compile without this include

### DIFF
--- a/include/some_types.h
+++ b/include/some_types.h
@@ -1,6 +1,8 @@
 #ifndef SOM_TYPES_H_INCLUDED
 #define SOM_TYPES_H_INCLUDED
 
+#include <cstdint>
+
 namespace hiberlite{
 
 template<class E, class C>


### PR DESCRIPTION
Include <cstdint> in some_types.h since it would not compile without it.